### PR TITLE
fix: Now it is not necessary dotenv to include .env files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "dotenv": "^16.4.7",
     "json-server": "^0.17.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
-require('dotenv').config()
+// require('dotenv').config()
+process.loadEnvFile()
 
 const jsonServer = require("json-server")
 


### PR DESCRIPTION
In the current versions of node, it is not necessary to use external dependencies to include .env files in projects

`process.loadEnvFile()
`